### PR TITLE
fix: isPatternFormatted on valid file

### DIFF
--- a/source/core/romSetup.cpp
+++ b/source/core/romSetup.cpp
@@ -473,7 +473,7 @@ PD777::isPatternFormatted(const void* patternData, const size_t patternDataSize)
     for(auto i = 0; i < 20; ++i) {
         if(header[i] != magicNumber[i]) return false;
     }
-    return false;
+    return true;
 }
 
 bool


### PR DESCRIPTION
Expected behavior:
* `isPatternFormatted()` on a valid file should return `true`, but does not.

Tested on 
* https://github.com/W88DodPECuThLOl/PD777supplement/blob/main/sample/NekkoRis/obj/nekkoris.ptn777

on macOS as part of another branch.


=======
Machine translation / 機械翻訳：
期待される動作：
* 有効なファイルに対して `isPatternFormatted()` を呼び出すと `true` が返されるはずですが、実際には返されません。

テスト対象：
* https://github.com/W88DodPECuThLOl/PD777supplement/blob/main/sample/NekkoRis/obj/nekkoris.ptn777

macOS 上で、別のブランチの一部としてテストを実施しました。