### PR TITLE
libretro fixes

### DIFF
--- a/source/libretro/LibretroPD777.cpp
+++ b/source/libretro/LibretroPD777.cpp
@@ -37,11 +37,8 @@ void LibretroPD777::present()
         const s32 offsetX = 10 * dotWidth;
         for(int y = 0; y < HEIGHT; y++) {
             for(int x = 0; x < WIDTH; x++) {
-                const auto bgr = frameBuffer[x + offsetX + (y*frameBufferWidth)];
-                const auto r = (bgr >> 16) & 0x0000FF;
-                const auto b = (bgr << 16) & 0xFF0000;
-                const auto g = (bgr      ) & 0x00FF00;
-                const auto argb  = BACKGROUND | r | g | b;
+                const auto rgb = frameBuffer[x + offsetX + (y*frameBufferWidth)];
+                const auto argb  = BACKGROUND | rgb;
                 image[x + y * WIDTH] = argb;
                 //image[x + y * WIDTH] = 0xFF44FF88;
 

--- a/source/libretro/libretro.cpp
+++ b/source/libretro/libretro.cpp
@@ -195,7 +195,10 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
     float aspect                = 0.0f;
     float sampling_rate         = 30000.0f;
 
-
+	info->timing = (struct retro_system_timing) {
+      .fps = 60.0,
+         .sample_rate = 0.0,
+    };
     info->geometry.base_width   = VIDEO_WIDTH;
     info->geometry.base_height  = VIDEO_HEIGHT;
     info->geometry.max_width    = VIDEO_WIDTH;
@@ -535,4 +538,5 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
     (void)enabled;
     (void)code;
 }
+
 

--- a/source/libretro/libretro.cpp
+++ b/source/libretro/libretro.cpp
@@ -192,21 +192,25 @@ retro_input_state_t input_state_cb;
 
 void retro_get_system_av_info(struct retro_system_av_info *info)
 {
-    float aspect                = 0.0f;
-    float sampling_rate         = 30000.0f;
+    /* NTSC precise framerate required for CRT SwitchRes modeline calculation.
+     * Using 60.0 instead of 60.0988 causes unstable sync on real CRT displays. */
+    float fps           = 60.0988f;
+    float sampling_rate = 48000.0f;
 
-	info->timing = (struct retro_system_timing) {
-      .fps = 60.0,
-         .sample_rate = 0.0,
+    info->timing = (struct retro_system_timing) {
+        .fps         = fps,
+        .sample_rate = sampling_rate,
     };
     info->geometry.base_width   = VIDEO_WIDTH;
     info->geometry.base_height  = VIDEO_HEIGHT;
     info->geometry.max_width    = VIDEO_WIDTH;
     info->geometry.max_height   = VIDEO_HEIGHT;
-    info->geometry.aspect_ratio = aspect;
+    /* Cassette Vision outputs a 4:3 display ratio.
+     * aspect_ratio = 0.0f was incorrect and caused image stretching. */
+    info->geometry.aspect_ratio = 4.0f / 3.0f;
 
-    last_aspect                 = aspect;
-    last_sample_rate            = sampling_rate;
+    last_aspect      = info->geometry.aspect_ratio;
+    last_sample_rate = sampling_rate;
 }
 
 void retro_set_environment(retro_environment_t cb)
@@ -538,5 +542,6 @@ void retro_cheat_set(unsigned index, bool enabled, const char *code)
     (void)enabled;
     (void)code;
 }
+
 
 


### PR DESCRIPTION
Fixes for libretro from the community.  The most important fixes colors to make the Yosaku player character orange/yellow rather than blue.

I have not squashed the commits as they are from other people, but could if you prefer.

機械翻訳：
コミュニティからのlibretroの修正です。最も重要な修正は、プレイヤーキャラクターのヨサクの色を青ではなくオレンジ/黄色に変更することです。

これらのコミットは他の方々によるものなので、まだ統合していませんが、ご希望であれば統合することも可能です。